### PR TITLE
Fix typos & ameliorate a `build_site()` error 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ There are two major use cases for the package:
 
 The toolset of the package includes
 
-- transforming species-trait-matrix or occurence table data into a unified long-table format
+- transforming species-trait-matrix or occurrence table data into a unified long-table format
 - mapping column names into terms provided in a standard trait vocabulary
 - matching of species names into GBIF Backbone Taxonomy (taxonomic ontology server)
-- matching of trait names into a user-provided traitlist, i.e. a thesaurus of traits
+- matching of trait names into a user-provided trait list, i.e. a thesaurus of traits
 - unifying trait values into target unit format and legit factor levels
 - saving trait dataset into a desired format using templates (e.g. for BExIS)
 
@@ -85,7 +85,7 @@ The datasets have been published by their authors under [Creative Commons 0](htt
 
 For additional information and interpretation of the data please refer to the help pages of the data objects (e.g. calling `?carabids` in R) and the original data sources given therein. 
 
-If you want  further datasources published under Creative Commons Licenses or in the public domain being added to this package, feel free to file a pull-request with a script for download and harmonization in the `data/` directory and a documentation appended to `R/data.R`! 
+If you want  further data sources published under Creative Commons Licenses or in the public domain being added to this package, feel free to file a pull-request with a script for download and harmonization in the `data/` directory and a documentation appended to `R/data.R`! 
 
 
 ## Contributing
@@ -103,7 +103,7 @@ We are aiming to provide the following features in future iterations of the pack
 - extracting trait definitions and hierarchies from semantic ontologies (e.g. from the OWL files or via APIs), to facilitate analysis of comparable traits across taxa. 
 - automated matching of user-provided trait names against trait definitions in online resources, by looking up traits from published ontologies.
 - harmonization of levels of factorial traits via fuzzy matching (requires lookup tables and ontologies providing legit factor levels). 
-- managing trait databases locally in R by managing relational data (e.g. on occurence level or measurement level, sampling event,  taxon etc.) in the data.frame attributes. 
+- managing trait databases locally in R by managing relational data (e.g. on occurrence level or measurement level, sampling event,  taxon etc.) in the data.frame attributes. 
 
 ## Cite as
 

--- a/vignettes/traitdataform.Rmd
+++ b/vignettes/traitdataform.Rmd
@@ -3,7 +3,7 @@ title: "Package 'traitdataform'"
 author: "Florian D. Schneider"
 output:  rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{traitdataform}
+  %\VignetteIndexEntry{Package 'traitdataform'}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 bibliography: div05.bib
@@ -26,7 +26,7 @@ There are two major use cases for the package:
 The toolset of the package includes
 
 1. transforming typical trait-data formats (e.g. species-trait-matrix or measurement-table data) into a unified long-table format and mapping column names into terms provided in the Ecological Trait-data Standard (ETS) (see section [1. Reading data](#reading-data)),
-2. mapping of trait concepts onto a user-provided traitlist (i.e. a thesaurus of traits) or globally accessible URIs  (see section [2. Standardize traits](#standardize-traits)) and unify units and factor levels,
+2. mapping of trait concepts onto a user-provided trait list (i.e. a thesaurus of traits) or globally accessible URIs  (see section [2. Standardize traits](#standardize-traits)) and unify units and factor levels,
 3. mapping of species concepts onto globally accessible definitions via URIs (pointing to GFBio taxonomic ontology server) (see section [3. Standardize taxa](#standardize-taxa)), 
 4. Merging and handling compiled trait-data, while keeping track of the metadata for each original dataset (see section [4. Working with trait-datasets](#working-with-trait-datasets)) 
 5. saving trait dataset into a desired format using templates (e.g. for project-specific databases or online repositories) (see section [5. Writing data](#writing-data)) 
@@ -97,7 +97,7 @@ heteroptera_raw <-  read.delim(url("https://ndownloader.figshare.com/files/56338
                                          encoding = "windows-1252"),
                                     stringsAsFactors=TRUE)
 
-# Data pulication: M. Gossner, Martin; K. Simons, Nadja; Hoeck, Leonhard; W.
+# Data publication: M. Gossner, Martin; K. Simons, Nadja; Hoeck, Leonhard; W.
 # Weisser, Wolfgang (2016): Morphometric measures of Heteroptera sampled in
 # grasslands across three regions of Germany. figshare.
 # https://doi.org/10.6084/m9.figshare.c.3307611.v1


### PR DESCRIPTION
Fixed typos in readme and .io landing page.

Ameliorated the error that is thrown on build_site() re: the \vignetteIndexEntry not matching the title in the yaml.