### PR TITLE
Fix devtools checks

### DIFF
--- a/inst/extdata/arthropodtraits.R
+++ b/inst/extdata/arthropodtraits.R
@@ -1,5 +1,5 @@
 # for roxygen2 documentation please edit file R/data.R!
-arthropodtraits <- utils::read.csv(url("https://datadryad.org/stash/downloads/file_stream/41660", 
+arthropodtraits <- utils::read.csv(url("https://datadryad.org/stash/downloads/file_stream/41139", 
                                        encoding = "latin1"), 
                                    sep = "\t",
                                    stringsAsFactors = FALSE

--- a/inst/extdata/carabids.R
+++ b/inst/extdata/carabids.R
@@ -1,6 +1,6 @@
 # for roxygen2 documentation please edit file R/data.R!
 
-carabids <- utils::read.delim(url("https://datadryad.org/stash/downloads/file_stream/24267", 
+carabids <- utils::read.delim(url("https://datadryad.org/stash/downloads/file_stream/23901", 
                                 encoding = "UTF-8"), 
                               stringsAsFactors = FALSE
                               )

--- a/vignettes/traitdataform.Rmd
+++ b/vignettes/traitdataform.Rmd
@@ -52,7 +52,7 @@ If reading files from a file repository, you can refer to the URL directly, e.g.
 ```{r, warning=FALSE, error=FALSE}
 # pulling data from van der Plas F, van Klink R, Manning P, Olff H, Fischer M (2017) Sensitivity of functional diversity metrics to sampling intensity. Methods in Ecology and Evolution 8(9): 1072-1080. https://doi.org/10.1111/2041-210x.12728
 
-carabids <- read.delim("https://datadryad.org/stash/downloads/file_stream/24267", stringsAsFactors = FALSE)
+carabids <- read.delim("https://datadryad.org/stash/downloads/file_stream/23901", stringsAsFactors = FALSE)
 
 ```
 


### PR DESCRIPTION
Hi @fdschneider,
as proposed in #44 here is a PR to fix devtools check.
The problem with the data is due to Dryad changing its file stream ids.
The best method to avoid this issue would be to instead download the data files with their DOIs which are stable.

I wanted to check the PR on other platforms than my local computer through `rhub`  but only the maintainer can.